### PR TITLE
disallow equal sign in attribute names

### DIFF
--- a/lib/MikroTik/API.pm
+++ b/lib/MikroTik/API.pm
@@ -383,7 +383,7 @@ sub talk {
     while ( ( $retval, @reply ) = $self->_read_sentence() ) {
         my %dataset;
         foreach my $line ( @reply ) {
-            if ( my ($key, $value) = ( $line =~ /^=(\S+)=(.*)/s ) ) {
+            if ( my ($key, $value) = ( $line =~ /^=([^=]+)=(.*)/s ) ) {
                 $dataset{$key} = $value;
             }
         }


### PR DESCRIPTION
Before:
    'path=/showthread.php?tid' => '273'
After:
    'path' => '/showthread.php?tid=273'

Thus it's possible now to have equal signs in the values.
