### PR TITLE
Avoid hanging on broken TCP connection

### DIFF
--- a/lib/MikroTik/API.pm
+++ b/lib/MikroTik/API.pm
@@ -162,6 +162,7 @@ sub login {
     push( @command, '=name=' . $self->get_username() );
     push( @command, '=response=00' . $md5->hexdigest() );
     ( $retval, @results ) = $self->talk( \@command );
+    die 'disconnected while logging in' if !defined $retval;
     if ( $retval > 1 ) {
         die $results[0]{'message'};
     }
@@ -199,6 +200,7 @@ sub cmd {
         push( @command, '='. $attr .'='. $attrs_href->{$attr} );
     }
     my ( $retval, @results ) = $self->talk( \@command );
+    die 'disconnected' if !defined $retval;
     if ($retval > 1) {
         die $results[0]{'message'};
     }
@@ -225,6 +227,7 @@ sub query {
         push( @command, '?'. $query .'='. $queries_href->{$query} );
     }
     my ( $retval, @results ) = $self->talk( \@command );
+    die 'disconnected' if !defined $retval;
     if ($retval > 1) {
         die $results[0]{'message'};
     }
@@ -244,6 +247,7 @@ sub get_by_key {
     my @command = ($cmd);
     my %ids;
     my ( $retval, @results ) = $self->talk( \@command );
+    die 'disconnected' if !defined $retval;
     if ($retval > 1) {
         die $results[0]{'message'};
     }

--- a/lib/MikroTik/API.pm
+++ b/lib/MikroTik/API.pm
@@ -121,6 +121,9 @@ sub connect {
     if ( ! $self->get_socket() ) {
         die "socket creation failed ($!)";
     }
+    $self->get_socket()->sockopt(SO_KEEPALIVE,1);
+    $self->get_socket()->sockopt(SO_RCVTIMEO,$self->get_timeout());
+    $self->get_socket()->sockopt(SO_SNDTIMEO,$self->get_timeout());
     return $self;
 }
 

--- a/lib/MikroTik/API.pm
+++ b/lib/MikroTik/API.pm
@@ -529,12 +529,7 @@ sub _read_word {
         my $length_received = 0;
         while ( $length_received < $len ) {
             my $line = '';
-            if ( ref $self->get_socket() eq 'IO::Socket::INET' ) {
-                $self->get_socket()->recv( $line, $len );
-            }
-            else { # IO::Socket::SSL does not implement recv()
-                $self->get_socket()->read( $line, $len );
-            }
+            $self->get_socket()->read( $line, $len );
 	    last if !defined($line) || $line eq ''; # EOF
             $ret_line .= $line; # append to $ret_line, in case we didn't get the whole word and are going round again
             $length_received += length $line;
@@ -597,12 +592,7 @@ sub _read_len {
 sub _read_byte{
     my ( $self ) = @_;
     my $line = '';
-    if ( ref $self->get_socket() eq 'IO::Socket::INET' ) {
-        $self->get_socket()->recv( $line, 1 );
-    }
-    else { # IO::Socket::SSL does not implement recv()
-        $self->get_socket()->read( $line, 1 );
-    }
+    $self->get_socket()->read( $line, 1 );
     die 'EOF' if !defined($line) || length($line) != 1;
     return ord($line);
 }


### PR DESCRIPTION
Sometimes the TCP connection is discarded by the remote side, thus API client hangs indefinitely. `SO_KEEPALIVE` should prevent it, but its timeout is quite large. Thus `SO_RCVTIMEO` and `SO_SNDTIMEO` options get handy.

Besides, when the connection breaks I get warnings about comparing undefined $retval, it's better to die in that case.

And finally, there is no point in using `recv` on TCP connections without options, it behaves exactly as plain `read`.